### PR TITLE
major changes to support rhel platform, enterprise edition and tarball installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,27 @@
-.kitchen
+*~
+.rbx
+*.class
+.kitchen/
 .kitchen.local.yml
-Berksfile.lock
 .idea
+tmp/
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+pkg/
+
+# Berkshelf
+.vagrant
+/cookbooks
+Berksfile.lock
+
+# Bundler
+.vendor
+Gemfile.lock
+bin/*
+.bundle/*
+.DS_Store
+coverage/
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,8 +9,8 @@ AllCops:
     - Thorfile
     - Gemfile
     - '.kitchen/*'
-    - 'spec/*'
-    - 'vendor/*'
+    - 'spec/**/*'
+    - 'vendor/**/*'
 
 Metrics/LineLength:
   Max: 200

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - Gemfile
     - '.kitchen/*'
     - 'spec/*'
+    - 'vendor/*'
 
 Metrics/LineLength:
   Max: 200

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,12 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   Exclude:
     - metadata.rb
+    - Rakefile
+    - Berksfile
+    - Vagrantfile
+    - Thorfile
+    - Gemfile
+    - '.kitchen/*'
 
 Metrics/LineLength:
   Max: 200

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - Thorfile
     - Gemfile
     - '.kitchen/*'
+    - 'spec/*'
 
 Metrics/LineLength:
   Max: 200

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: false
 cache: bundler
 bundler_args: --without development
-script: 'bundle exec rspec'
+script: 'bundle exec rake lint'
 gemfile:
   - Gemfile
 rvm:

--- a/Berksfile
+++ b/Berksfile
@@ -4,3 +4,4 @@ metadata
 
 cookbook 'apt', '~> 2.7.0'
 cookbook 'java', '~> 1.31.0'
+cookbook 'yum', '~> 3.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,15 @@ source 'https://rubygems.org'
 
 gem 'berkshelf'
 gem 'chefspec'
+gem 'rake'
+gem 'foodcritic'
+gem 'rubocop'
 
 group :development do
-  gem 'foodcritic'
   gem 'guard'
   gem 'guard-foodcritic'
   gem 'guard-rspec'
   gem 'guard-rubocop'
   gem 'kitchen-vagrant', '~> 0.15.0'
-  gem 'rubocop'
   gem 'test-kitchen'
 end

--- a/Guardfile
+++ b/Guardfile
@@ -15,6 +15,6 @@ end
 
 guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^recipes/(.+)\.rb$})     { |m| "spec/recipes/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { 'spec' }
+  watch(%r{^recipes/(.+)\.rb$}) { |m| "spec/recipes/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb') { 'spec' }
 end

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ neo4j Cookbook
 [![Build Status](https://travis-ci.org/czeeb/neo4j-cookbook.svg?branch=master)](https://travis-ci.org/czeeb/neo4j-cookbook)
 [![Dependency Status](https://gemnasium.com/czeeb/neo4j-cookbook.svg)](https://gemnasium.com/czeeb/neo4j-cookbook)
 
-This cookbook installs neo4j.
+This is a [Chef] cookbook to manage [Neo4j] (Community & Enterprise Edition).
 
 Platforms
 ---------
@@ -11,6 +11,7 @@ The following platforms and versions are tested and supported using [test-kitche
 
 * Debian 7.8, 8.1
 * Ubuntu 12.04, 14.04
+* Amazon Linux 2015-03
 
 Attributes
 ----------
@@ -21,62 +22,62 @@ Wherever possible I use the default settings from Neo4j for the defaults in the 
 
 ### neo4j-server.properties
 
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.database.location']` - location of the database directory
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.db.tuning.properties']` - Low-level graph tuning engine file
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.address']` - web server port
-* `node['neo4j']['neo4j-server.properties']['dbms.security.auth_enabled']` - Enabled or disable auth to access neo4j
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.port']` - Web server port
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.enabled']` - Turn https support on/off
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.https.port']` - https port
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.cert.location']` - SSL cert location
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.key.location']` - SSL key location
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.keystore.location']` - keystore location
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.http.log.enabled']` - enable/disable http logging
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.http.log.config']` - http logging config
-* `node['neo4j']['neo4j-server.properties']['org.neo4j.server.webadmin.rrdb.location']` - location of rrd database directory
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.database.location']` - location of the database directory
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.db.tuning.properties']` - Low-level graph tuning engine file
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.address']` - web server port
+* `node['neo4j']['config']['neo4j-server.properties']['dbms.security.auth_enabled']` - Enabled or disable auth to access neo4j
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.port']` - Web server port
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.https.enabled']` - Turn https support on/off
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.https.port']` - https port
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.https.cert.location']` - SSL cert location
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.https.key.location']` - SSL key location
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.https.keystore.location']` - keystore location
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.http.log.enabled']` - enable/disable http logging
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.http.log.config']` - http logging config
+* `node['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webadmin.rrdb.location']` - location of rrd database directory
 
 ### neo4j-server.properties
 
 [Neo4j Documentation](http://neo4j.com/docs/stable/configuration-settings.html)
 
-* `node['neo4j']['neo4j.properties']['allow_store_upgrade']` - Enable this to be able to upgrade a store from an older version
-* `node['neo4j']['neo4j.properties']['dbms.pagecache.memory']` - Set pagecache memory to use. Neo4j usually does a good job of figuring this out on its own
-* `node['neo4j']['neo4j.properties']['cypher_parser_version']` - Enable this to specify a parser other than the default one
-* `node['neo4j']['neo4j.properties']['keep_logical_logs']` - Keep logical logs
-* `node['neo4j']['neo4j.properties']['node_auto_indexing']` - Enable auto-indexing for nodes
-* `node['neo4j']['neo4j.properties']['node_keys_indexable']` - The node property keys to be auto-indexed
-* `node['neo4j']['neo4j.properties']['relationship_auto_indexing']` - Enable auto-indexing for relationships
-* `node['neo4j']['neo4j.properties']['relationship_keys_indexable']` - The relationship property keys to be auto-indexed, if enabled
-* `node['neo4j']['neo4j.properties']['remote_shell_enabled']` - Enable shell server so that remote clients can connect via Neo4j shell
-* `node['neo4j']['neo4j.properties']['remote_shell_host']` - The network interface IP the shell will listen on (use 0.0.0 for all interfaces)
-* `node['neo4j']['neo4j.properties']['remote_shell_port']` - The port the shell will listen on
-* `node['neo4j']['neo4j.properties']['cache_type']` - The type of cache to use for nodes and relationships.
-* `node['neo4j']['neo4j.properties']['allow_file_urls']` - Determines if Cypher will allow using file URLs when loading data using LOAD CSV
-* `node['neo4j']['neo4j.properties']['dbms.cypher.min_replan_interval']` - The minimum lifetime of a query plan before a query is considered for replanning.
-* `node['neo4j']['neo4j.properties']['dbms.cypher.planner']` - Set this to specify the default planner.
-* `node['neo4j']['neo4j.properties']['dbms.querylog.enabled']` - Log executed queries that takes longer than the configured threshold.
-* `node['neo4j']['neo4j.properties']['dbms.querylog.filename']` - The file where queries will be recorded.
-* `node['neo4j']['neo4j.properties']['dbms.querylog.threshold']` - If the execution of query takes more time than this threshold, the query is logged - provided query logging is enabled.
-* `node['neo4j']['neo4j.properties']['dense_node_threshold']` - Relationship count threshold for considering a node to be dense.
-* `node['neo4j']['neo4j.properties']['dump_configuration']` - Print out the effective Neo4j configuration after startup.
-* `node['neo4j']['neo4j.properties']['index_background_sampling_enabled']` - Enable or disable background index sampling.
-* `node['neo4j']['neo4j.properties']['index_sampling_buffer_size']` - Size of buffer used by index sampling.
-* `node['neo4j']['neo4j.properties']['index_sampling_update_percentage']` - Percentage of index updates of total index size required before sampling of a given index is triggered.
-* `node['neo4j']['neo4j.properties']['logical_log_rotation_threshold']` - Specifies at which file size the logical log will auto-rotate.
-* `node['neo4j']['neo4j.properties']['lucene_searcher_cache_size']` - The maximum number of open Lucene index searchers.
-* `node['neo4j']['neo4j.properties']['query_cache_size']` - The number of Cypher query execution plans that are cached.
-* `node['neo4j']['neo4j.properties']['read_only']` - Only allow read operations from this Neo4j instance.
-* `node['neo4j']['neo4j.properties']['relationship_grab_size']` - How many relationships to read at a time during iteration.
-* `node['neo4j']['neo4j.properties']['remote_logging_enabled']` - Whether to enable logging to a remote server or not.
-* `node['neo4j']['neo4j.properties']['remote_logging_host']` - Host for remote logging using Logback SocketAppender.
-* `node['neo4j']['neo4j.properties']['remote_logging_port']` - Port for remote logging using Logback SocketAppender.
-* `node['neo4j']['neo4j.properties']['store_dir']` - The directory where the database files are located.
+* `node['neo4j']['config']['neo4j.properties']['allow_store_upgrade']` - Enable this to be able to upgrade a store from an older version
+* `node['neo4j']['config']['neo4j.properties']['dbms.pagecache.memory']` - Set pagecache memory to use. Neo4j usually does a good job of figuring this out on its own
+* `node['neo4j']['config']['neo4j.properties']['cypher_parser_version']` - Enable this to specify a parser other than the default one
+* `node['neo4j']['config']['neo4j.properties']['keep_logical_logs']` - Keep logical logs
+* `node['neo4j']['config']['neo4j.properties']['node_auto_indexing']` - Enable auto-indexing for nodes
+* `node['neo4j']['config']['neo4j.properties']['node_keys_indexable']` - The node property keys to be auto-indexed
+* `node['neo4j']['config']['neo4j.properties']['relationship_auto_indexing']` - Enable auto-indexing for relationships
+* `node['neo4j']['config']['neo4j.properties']['relationship_keys_indexable']` - The relationship property keys to be auto-indexed, if enabled
+* `node['neo4j']['config']['neo4j.properties']['remote_shell_enabled']` - Enable shell server so that remote clients can connect via Neo4j shell
+* `node['neo4j']['config']['neo4j.properties']['remote_shell_host']` - The network interface IP the shell will listen on (use 0.0.0 for all interfaces)
+* `node['neo4j']['config']['neo4j.properties']['remote_shell_port']` - The port the shell will listen on
+* `node['neo4j']['config']['neo4j.properties']['cache_type']` - The type of cache to use for nodes and relationships.
+* `node['neo4j']['config']['neo4j.properties']['allow_file_urls']` - Determines if Cypher will allow using file URLs when loading data using LOAD CSV
+* `node['neo4j']['config']['neo4j.properties']['dbms.cypher.min_replan_interval']` - The minimum lifetime of a query plan before a query is considered for replanning.
+* `node['neo4j']['config']['neo4j.properties']['dbms.cypher.planner']` - Set this to specify the default planner.
+* `node['neo4j']['config']['neo4j.properties']['dbms.querylog.enabled']` - Log executed queries that takes longer than the configured threshold.
+* `node['neo4j']['config']['neo4j.properties']['dbms.querylog.filename']` - The file where queries will be recorded.
+* `node['neo4j']['config']['neo4j.properties']['dbms.querylog.threshold']` - If the execution of query takes more time than this threshold, the query is logged - provided query logging is enabled.
+* `node['neo4j']['config']['neo4j.properties']['dense_node_threshold']` - Relationship count threshold for considering a node to be dense.
+* `node['neo4j']['config']['neo4j.properties']['dump_configuration']` - Print out the effective Neo4j configuration after startup.
+* `node['neo4j']['config']['neo4j.properties']['index_background_sampling_enabled']` - Enable or disable background index sampling.
+* `node['neo4j']['config']['neo4j.properties']['index_sampling_buffer_size']` - Size of buffer used by index sampling.
+* `node['neo4j']['config']['neo4j.properties']['index_sampling_update_percentage']` - Percentage of index updates of total index size required before sampling of a given index is triggered.
+* `node['neo4j']['config']['neo4j.properties']['logical_log_rotation_threshold']` - Specifies at which file size the logical log will auto-rotate.
+* `node['neo4j']['config']['neo4j.properties']['lucene_searcher_cache_size']` - The maximum number of open Lucene index searchers.
+* `node['neo4j']['config']['neo4j.properties']['query_cache_size']` - The number of Cypher query execution plans that are cached.
+* `node['neo4j']['config']['neo4j.properties']['read_only']` - Only allow read operations from this Neo4j instance.
+* `node['neo4j']['config']['neo4j.properties']['relationship_grab_size']` - How many relationships to read at a time during iteration.
+* `node['neo4j']['config']['neo4j.properties']['remote_logging_enabled']` - Whether to enable logging to a remote server or not.
+* `node['neo4j']['config']['neo4j.properties']['remote_logging_host']` - Host for remote logging using Logback SocketAppender.
+* `node['neo4j']['config']['neo4j.properties']['remote_logging_port']` - Port for remote logging using Logback SocketAppender.
+* `node['neo4j']['config']['neo4j.properties']['store_dir']` - The directory where the database files are located.
 
 ### neo4j-wrapper.conf
-* `node['neo4j']['neo4j-wrapper.conf']['wrapper.java.additional'] - Array of arguements to pass to java
-* `node['neo4j']['neo4j-wrapper.conf']['wrapper.java.initmemory'] - Set heap size
-* `node['neo4j']['neo4j-wrapper.conf']['wrapper.java.maxmemory'] - Set heap size maximum
-* `node['neo4j']['neo4j-wrapper.conf']['wrapper.pidfile'] - Set pidfile
+* `node['neo4j']['config']['neo4j-wrapper.conf']['wrapper.java.additional'] - Array of arguements to pass to java
+* `node['neo4j']['config']['neo4j-wrapper.conf']['wrapper.java.initmemory'] - Set heap size
+* `node['neo4j']['config']['neo4j-wrapper.conf']['wrapper.java.maxmemory'] - Set heap size maximum
+* `node['neo4j']['config']['neo4j-wrapper.conf']['wrapper.pidfile'] - Set pidfile
 
 Usage
 -----
@@ -106,7 +107,7 @@ e.g.
 
 License and Authors
 -------------------
-Authors: Chris Zeeb <chris.zeeb@gmail.com>
+Authors: Chris Zeeb <chris.zeeb@gmail.com> and [Contributors]
 
 ```text
 Copyright:: 2015 Chris Zeeb <chris.zeeb@gmail.com>
@@ -123,3 +124,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+[Chef]: https://www.chef.io
+[Neo4j]: http://neo4j.com
+[Contributors]: https://github.com/czeeb/neo4j-cookbook/graphs/contributors

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,38 @@
+#!/usr/bin/env rake
+
+require 'foodcritic'
+require 'rubocop/rake_task'
+require 'rspec/core/rake_task'
+
+desc 'Run all lints'
+task :lint => %w(foodcritic rubocop)
+#task :lint => %w(foodcritic rubocop knife spec)
+task :default => :lint
+
+desc 'Run Rubocop Lint Task'
+task :rubocop do
+  puts "Running Rubocop Lint.."
+  RuboCop::RakeTask.new
+end
+
+desc 'Run Food Critic Lint Task'
+task :foodcritic do
+  puts "Running Food Critic Lint.."
+  FoodCritic::Rake::LintTask.new do |fc|
+    fc.options = {:fail_tags => ['any']}
+  end
+end
+
+desc 'Run Knife Cookbook Test Task'
+task :knife do
+  puts "Running Knife Check.."
+  current_dir = File.expand_path(File.dirname(__FILE__))
+  cookbook_dir = File.dirname(current_dir)
+  cookbook_name = File.basename(current_dir)
+  sh "bundle exec knife cookbook test -o #{cookbook_dir} #{cookbook_name}"
+end
+
+desc 'Run Chef Spec Test'
+task :spec do
+  RSpec::Core::RakeTask.new(:spec)
+end

--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,7 @@ require 'rubocop/rake_task'
 require 'rspec/core/rake_task'
 
 desc 'Run all lints'
-task :lint => %w(foodcritic rubocop)
-#task :lint => %w(foodcritic rubocop knife spec)
+task :lint => %w(foodcritic rubocop spec)
 task :default => :lint
 
 desc 'Run Rubocop Lint Task'

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -1,0 +1,77 @@
+# neo4j-server.properties
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.database.location'] = node['neo4j']['data_dir']
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.db.tuning.properties'] = 'conf/neo4j.properties'
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.address'] = node['ipaddress']
+default['neo4j']['config']['neo4j-server.properties']['dbms.security.auth_enabled'] = true
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.port'] = 7474
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.https.enabled'] = true
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.https.port'] = 7473
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.https.cert.location'] = 'conf/ssl/snakeoil.cert'
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.https.key.location'] = 'conf/ssl/snakeoil.key'
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.https.keystore.location'] = 'data/keystore'
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.http.log.enabled'] = false
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.http.log.config'] = 'conf/neo4j-http-logging.xml'
+default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webadmin.rrdb.location'] = 'data/rrd'
+
+# neo4j.properties
+default['neo4j']['config']['neo4j.properties']['allow_store_upgrade'] = nil
+default['neo4j']['config']['neo4j.properties']['dbms.pagecache.memory'] = nil
+default['neo4j']['config']['neo4j.properties']['cypher_parser_version'] = nil
+default['neo4j']['config']['neo4j.properties']['keep_logical_logs'] = '7 days'
+default['neo4j']['config']['neo4j.properties']['node_auto_indexing'] = nil
+default['neo4j']['config']['neo4j.properties']['node_keys_indexable'] = nil
+default['neo4j']['config']['neo4j.properties']['relationship_auto_indexing'] = nil
+default['neo4j']['config']['neo4j.properties']['relationship_keys_indexable'] = nil
+default['neo4j']['config']['neo4j.properties']['remote_shell_enabled'] = false
+default['neo4j']['config']['neo4j.properties']['remote_shell_host'] = '127.0.0.1'
+default['neo4j']['config']['neo4j.properties']['remote_shell_port'] = 1337
+default['neo4j']['config']['neo4j.properties']['cache_type'] = nil
+default['neo4j']['config']['neo4j.properties']['allow_file_urls'] = true
+default['neo4j']['config']['neo4j.properties']['dbms.cypher.min_replan_interval'] = nil
+default['neo4j']['config']['neo4j.properties']['dbms.cypher.planner'] = nil
+default['neo4j']['config']['neo4j.properties']['dbms.querylog.enabled'] = false
+default['neo4j']['config']['neo4j.properties']['dbms.querylog.filename'] = nil
+default['neo4j']['config']['neo4j.properties']['dbms.querylog.threshold'] = nil
+default['neo4j']['config']['neo4j.properties']['dense_node_threshold'] = nil
+default['neo4j']['config']['neo4j.properties']['dump_configuration'] = nil
+default['neo4j']['config']['neo4j.properties']['index_background_sampling_enabled'] = nil
+default['neo4j']['config']['neo4j.properties']['index_sampling_buffer_size'] = nil
+default['neo4j']['config']['neo4j.properties']['index_sampling_update_percentage'] = nil
+default['neo4j']['config']['neo4j.properties']['logical_log_rotation_threshold'] = nil
+default['neo4j']['config']['neo4j.properties']['logical_log'] = ::File.join(node['neo4j']['log_dir'], 'logical.log')
+default['neo4j']['config']['neo4j.properties']['lucene_searcher_cache_size'] = nil
+default['neo4j']['config']['neo4j.properties']['query_cache_size'] = nil
+default['neo4j']['config']['neo4j.properties']['read_only'] = nil
+default['neo4j']['config']['neo4j.properties']['relationship_grab_size'] = nil
+default['neo4j']['config']['neo4j.properties']['remote_logging_enabled'] = nil
+default['neo4j']['config']['neo4j.properties']['remote_logging_host'] = nil
+default['neo4j']['config']['neo4j.properties']['remote_logging_port'] = nil
+default['neo4j']['config']['neo4j.properties']['store_dir'] = nil
+
+# neo4j-wrapper
+default['neo4j']['config']['neo4j-wrapper.conf']['wrapper.java.additional'] = %w(
+  -Dorg.neo4j.server.properties=conf/neo4j-server.properties
+  -Djava.util.logging.config.file=conf/logging.properties
+  -XX:+UseConcMarkSweepGC
+  -XX:+CMSClassUnloadingEnabled
+  -XX:-OmitStackTraceInFastThrow
+  -XX:hashCode=5
+)
+
+default['neo4j']['config']['neo4j-wrapper.conf']['wrapper.pidfile'] = node['neo4j']['pid_file']
+default['neo4j']['config']['neo4j-wrapper.conf']['wrapper.name'] = 'neo4j'
+default['neo4j']['config']['neo4j-wrapper.conf']['wrapper.user'] = 'neo4j'
+
+# logging.properties
+default['neo4j']['config']['logging.properties']['handlers'] = 'java.util.logging.FileHandler, java.util.logging.ConsoleHandler'
+default['neo4j']['config']['logging.properties']['.level'] = 'INFO'
+default['neo4j']['config']['logging.properties']['org.neo4j.server.level'] = 'INFO'
+default['neo4j']['config']['logging.properties']['java.util.logging.ConsoleHandler.level'] = 'INFO'
+default['neo4j']['config']['logging.properties']['java.util.logging.ConsoleHandler.formatter'] = 'org.neo4j.server.logging.SimpleConsoleFormatter'
+default['neo4j']['config']['logging.properties']['java.util.logging.ConsoleHandler.filter'] = 'org.neo4j.server.logging.NeoLogFilter'
+default['neo4j']['config']['logging.properties']['java.util.logging.FileHandler.level'] = 'ALL'
+default['neo4j']['config']['logging.properties']['java.util.logging.FileHandler.pattern'] = ::File.join(node['neo4j']['log_dir'], 'neo4j.%u.%g.log')
+default['neo4j']['config']['logging.properties']['java.util.logging.FileHandler.append'] = true
+default['neo4j']['config']['logging.properties']['java.util.logging.FileHandler.limit'] = '10000000'
+default['neo4j']['config']['logging.properties']['java.util.logging.FileHandler.count'] = '10'
+default['neo4j']['config']['logging.properties']['java.util.logging.FileHandler.formatter'] = 'java.util.logging.SimpleFormatter'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,7 +42,11 @@ default['neo4j']['home_dir']  = case node['neo4j']['install_method']
 
 # this works for both package and tarball
 default['neo4j']['conf_dir'] = ::File.join(node['neo4j']['home_dir'], 'conf')
-default['neo4j']['data_dir'] = ::File.join(node['neo4j']['home_dir'], 'data', 'graph.db')
+default['neo4j']['data_dir'] = value_for_platform_family(
+  'debian' => ::File.join(node['neo4j']['home_dir'], 'data', 'graph.db'),
+  'rhel' => '/var/lib/neo4j'
+)
+
 default['neo4j']['pid_file'] = ::File.join(node['neo4j']['home_dir'], 'data', 'neo4j-service.pid')
 default['neo4j']['auth_dir'] = ::File.join(node['neo4j']['home_dir'], 'data', 'dbms')
 default['neo4j']['auth_file'] = ::File.join(node['neo4j']['auth_dir'], 'auth')

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,68 +1,58 @@
-default['java']['install_flavor'] = 'oracle'
-default['java']['jdk_version'] = 7
-default['java']['oracle']['accept_oracle_download_terms'] = true
 
-default['neo4j']['release'] = '2.2.3'
+default['neo4j']['release'] = '2.2.4'
+default['neo4j']['release_suffix'] = node['platform_family'] == 'rhel' ? '-1' : ''
+default['neo4j']['edition'] = 'community' # options: community, enterprise
+default['neo4j']['install_java']    = true
+default['neo4j']['install_method']  = 'package' # options: package, tarball
+default['neo4j']['package'] = node['neo4j']['edition'] == 'community' ? 'neo4j' : 'neo4j-' + node['neo4j']['edition']
 
-# neo4j-server.properties
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.database.location'] = 'data/graph.db'
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.db.tuning.properties'] = 'conf/neo4j.properties'
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.address'] = 'localhost'
-default['neo4j']['neo4j-server.properties']['dbms.security.auth_enabled'] = true
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.port'] = 7474
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.enabled'] = true
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.https.port'] = 7473
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.cert.location'] = 'conf/ssl/snakeoil.cert'
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.key.location'] = 'conf/ssl/snakeoil.key'
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.keystore.location'] = 'data/keystore'
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.http.log.enabled'] = false
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.http.log.config'] = 'conf/neo4j-http-logging.xml'
-default['neo4j']['neo4j-server.properties']['org.neo4j.server.webadmin.rrdb.location'] = 'data/rrd'
+# tarball sources
+default['neo4j']['tarball_url'] = "http://neo4j.com/artifact.php?name=neo4j-#{node['neo4j']['edition']}-#{node['neo4j']['release']}-unix.tar.gz"
+default['neo4j']['tarball_checksum']['2.2.4']['community']  = 'b3fa5d547e50c3f619e39290266979e72f7222be7644fbb3bad2fc31d074aab9'
+default['neo4j']['tarball_checksum']['2.2.4']['enterprise'] = 'fc75a9cb161e9704ee0059e828f135637e17493328a783d979f3d6ead7fd86bf'
 
-# neo4j.properties
-default['neo4j']['neo4j.properties']['allow_store_upgrade'] = nil
-default['neo4j']['neo4j.properties']['dbms.pagecache.memory'] = nil
-default['neo4j']['neo4j.properties']['cypher_parser_version'] = nil
-default['neo4j']['neo4j.properties']['keep_logical_logs'] = '7 days'
-default['neo4j']['neo4j.properties']['node_auto_indexing'] = nil
-default['neo4j']['neo4j.properties']['node_keys_indexable'] = nil
-default['neo4j']['neo4j.properties']['relationship_auto_indexing'] = nil
-default['neo4j']['neo4j.properties']['relationship_keys_indexable'] = nil
-default['neo4j']['neo4j.properties']['remote_shell_enabled'] = false
-default['neo4j']['neo4j.properties']['remote_shell_host'] = '127.0.0.1'
-default['neo4j']['neo4j.properties']['remote_shell_port'] = 1337
-default['neo4j']['neo4j.properties']['cache_type'] = nil
-default['neo4j']['neo4j.properties']['allow_file_urls'] = true
-default['neo4j']['neo4j.properties']['dbms.cypher.min_replan_interval'] = nil
-default['neo4j']['neo4j.properties']['dbms.cypher.planner'] = nil
-default['neo4j']['neo4j.properties']['dbms.querylog.enabled'] = false
-default['neo4j']['neo4j.properties']['dbms.querylog.filename'] = nil
-default['neo4j']['neo4j.properties']['dbms.querylog.threshold'] = nil
-default['neo4j']['neo4j.properties']['dense_node_threshold'] = nil
-default['neo4j']['neo4j.properties']['dump_configuration'] = nil
-default['neo4j']['neo4j.properties']['index_background_sampling_enabled'] = nil
-default['neo4j']['neo4j.properties']['index_sampling_buffer_size'] = nil
-default['neo4j']['neo4j.properties']['index_sampling_update_percentage'] = nil
-default['neo4j']['neo4j.properties']['logical_log_rotation_threshold'] = nil
-default['neo4j']['neo4j.properties']['lucene_searcher_cache_size'] = nil
-default['neo4j']['neo4j.properties']['query_cache_size'] = nil
-default['neo4j']['neo4j.properties']['read_only'] = nil
-default['neo4j']['neo4j.properties']['relationship_grab_size'] = nil
-default['neo4j']['neo4j.properties']['remote_logging_enabled'] = nil
-default['neo4j']['neo4j.properties']['remote_logging_host'] = nil
-default['neo4j']['neo4j.properties']['remote_logging_port'] = nil
-default['neo4j']['neo4j.properties']['store_dir'] = nil
+# tarball install directory locations
+default['neo4j']['parent_dir']  = '/usr/local/neo4j'
+default['neo4j']['install_dir'] = ::File.join(node['neo4j']['parent_dir'], 'neo4j')
+default['neo4j']['source_dir']  = ::File.join(node['neo4j']['parent_dir'], "neo4j-#{node['neo4j']['edition']}-#{node['neo4j']['release']}")
 
-# neo4j-wrapper.conf
-default['neo4j']['neo4j-wrapper.conf']['wrapper.java.additional'] = %w(
-  -Dorg.neo4j.server.properties=conf/neo4j-server.properties
-  -Djava.util.logging.config.file=conf/logging.properties
-  -XX:+UseConcMarkSweepGC
-  -XX:+CMSClassUnloadingEnabled
-  -XX:-OmitStackTraceInFastThrow
-  -XX:hashCode=5
-  -Dneo4j.ext.udc.source=debian
+default['neo4j']['service_action'] = [:enable, :start]
+default['neo4j']['notify_restart'] = true
+
+# cookbook for configuration files template resources
+default['neo4j']['cookbook'] = 'neo4j'
+
+default['neo4j']['chef_backup'] = 5
+
+default['neo4j']['user']        = 'neo4j'
+default['neo4j']['user_group']  = node['platform_family'] == 'rhel' ? 'neo4j' : 'nogroup'
+default['neo4j']['group']       = node['platform_family'] == 'rhel' ? 'neo4j' : 'adm'
+default['neo4j']['setup_user']  = true # for tarball install
+
+default['neo4j']['log_dir']   = '/var/log/neo4j'
+default['neo4j']['home_dir']  = case node['neo4j']['install_method']
+                                when 'package'
+                                  value_for_platform_family(
+                                    'debian' => '/var/lib/neo4j',
+                                    'rhel' => '/usr/share/neo4j'
+                                  )
+                                else
+                                  node['neo4j']['install_dir']
+                                end
+
+# this works for both package and tarball
+default['neo4j']['conf_dir'] = ::File.join(node['neo4j']['home_dir'], 'conf')
+default['neo4j']['data_dir'] = ::File.join(node['neo4j']['home_dir'], 'data', 'graph.db')
+default['neo4j']['pid_file'] = ::File.join(node['neo4j']['home_dir'], 'data', 'neo4j-service.pid')
+default['neo4j']['auth_dir'] = ::File.join(node['neo4j']['home_dir'], 'data', 'dbms')
+default['neo4j']['auth_file'] = ::File.join(node['neo4j']['auth_dir'], 'auth')
+
+default['neo4j']['umask'] = '0022'
+default['neo4j']['mode']  = '0755'
+
+default['neo4j']['initd_file'] = value_for_platform_family(
+  'debian' => '/etc/init.d/neo4j-service',
+  'rhel' => '/etc/init.d/neo4j'
 )
-default['neo4j']['neo4j-wrapper.conf']['wrapper.java.initmemory'] = nil
-default['neo4j']['neo4j-wrapper.conf']['wrapper.java.maxmemory'] = nil
-default['neo4j']['neo4j-wrapper.conf']['wrapper.pidfile'] = '../data/neo4j-server.pid'
+
+default['neo4j']['limits']['files'] = 48_000

--- a/attributes/memory.rb
+++ b/attributes/memory.rb
@@ -1,0 +1,15 @@
+
+default['neo4j']['config']['neo4j-wrapper.conf']['wrapper.java.initmemory'] = 512
+
+fail 'missing node memory attribute' if !node['memory'] && !node['memory'].key?('total')
+
+# total memory in MB
+total_memory = (node['memory']['total'].to_i / 1024).to_i
+
+half_memory = total_memory / 2
+half_memory += 1 unless half_memory.even?
+if half_memory >= 32_768
+  default['neo4j']['config']['neo4j-wrapper.conf']['wrapper.java.maxmemory'] = 32_768
+else
+  default['neo4j']['config']['neo4j-wrapper.conf']['wrapper.java.maxmemory'] = nil
+end

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -1,0 +1,14 @@
+
+default['neo4j']['yum']['description'] = 'Neo4j Repository'
+default['neo4j']['yum']['gpgcheck'] = true
+default['neo4j']['yum']['enabled'] = true
+default['neo4j']['yum']['baseurl'] = 'http://yum.neo4j.org'
+default['neo4j']['yum']['gpgkey'] = 'http://debian.neo4j.org/neotechnology.gpg.key'
+default['neo4j']['yum']['mirrorlist'] = nil
+default['neo4j']['yum']['action'] = :create
+
+default['neo4j']['apt']['description'] = 'Neo4j Repository'
+default['neo4j']['apt']['components'] = ['stable/']
+default['neo4j']['apt']['action'] = :add
+default['neo4j']['apt']['uri'] = 'http://debian.neo4j.org/repo'
+default['neo4j']['apt']['key'] = 'http://debian.neo4j.org/neotechnology.gpg.key'

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,105 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml
+
+# Coverage #
+##########
+coverage/
+
+# Berkshelf
+Berksfile.lock
+
+# Bundler
+Gemfile.lock
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,5 +10,10 @@ version          '0.1.0'
 supports 'debian', '>= 7.8'
 supports 'ubuntu', '>= 12.04'
 
+supports 'centos'
+supports 'amazon'
+supports 'redhat'
+
+depends 'yum', '~> 2.7.0'
 depends 'apt', '~> 2.7.0'
 depends 'java', '~> 1.31.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,6 @@ supports 'centos'
 supports 'amazon'
 supports 'redhat'
 
-depends 'yum', '~> 2.7.0'
+depends 'yum', '~> 3.2.0'
 depends 'apt', '~> 2.7.0'
 depends 'java', '~> 1.31.0'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -16,37 +16,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_recipe 'neo4j::service'
 
 # Template for /etc/neo4j/neo4j-server.properties
-template '/etc/neo4j/neo4j-server.properties' do
-  action :create
+template ::File.join(node['neo4j']['conf_dir'], 'neo4j-server.properties') do
   source 'neo4j-server.properties.erb'
-  owner 'neo4j'
-  group 'adm'
+  owner node['neo4j']['user']
+  group node['neo4j']['group']
   mode '0644'
-  backup 1
-  notifies :restart, 'service[neo4j-service]', :delayed
+  backup node['neo4j']['chef_backup']
+  variables(:config => node['neo4j']['config']['neo4j-server.properties'])
+  notifies :restart, 'service[neo4j]', :delayed if node['neo4j']['notify_restart']
 end
 
 # Template for /etc/neo4j/neo4j.properties
-template '/etc/neo4j/neo4j.properties' do
-  action :create
+template ::File.join(node['neo4j']['conf_dir'], 'neo4j.properties') do
   source 'neo4j.properties.erb'
-  owner 'neo4j'
-  group 'adm'
+  owner node['neo4j']['user']
+  group node['neo4j']['group']
   mode '0644'
-  backup 1
-  notifies :restart, 'service[neo4j-service]', :delayed
+  backup node['neo4j']['chef_backup']
+  variables(:config => node['neo4j']['config']['neo4j.properties'])
+  notifies :restart, 'service[neo4j]', :delayed if node['neo4j']['notify_restart']
 end
 
-# Template for /etc/neo4j/neo4j.properties
-template '/etc/neo4j/neo4j-wrapper.conf' do
-  action :create
+# Template for /etc/neo4j/neo4j-wrapper.conf
+template ::File.join(node['neo4j']['conf_dir'], 'neo4j-wrapper.conf') do
   source 'neo4j-wrapper.conf.erb'
-  owner 'neo4j'
-  group 'adm'
+  owner node['neo4j']['user']
+  group node['neo4j']['group']
   mode '0644'
-  backup 1
-  notifies :restart, 'service[neo4j-service]', :delayed
+  backup node['neo4j']['chef_backup']
+  variables(:config => node['neo4j']['config']['neo4j-wrapper.conf'])
+  notifies :restart, 'service[neo4j]', :delayed if node['neo4j']['notify_restart']
 end
+
+# Template for /etc/neo4j/logging.properties
+template ::File.join(node['neo4j']['conf_dir'], 'logging.properties') do
+  source 'logging.properties.erb'
+  owner node['neo4j']['user']
+  group node['neo4j']['group']
+  mode '0644'
+  variables(:config => node['neo4j']['config']['logging.properties'])
+  notifies :restart, 'service[neo4j]', :delayed if node['neo4j']['notify_restart']
+end
+
+include_recipe 'neo4j::service'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -17,13 +17,23 @@
 # limitations under the License.
 #
 
-apt_repository 'neo4j' do
-  uri 'http://debian.neo4j.org/repo'
-  components ['stable/']
-  key 'http://debian.neo4j.org/neotechnology.gpg.key'
-end
+fail "invalid value `#{node['neo4j']['install_method']}` for `node['neo4j']['install_method']`, valid are `package tarball`" unless %w(package tarball).include?(node['neo4j']['install_method'])
 
-package 'neo4j' do
-  action :install
-  version node['neo4j']['release']
+fail "invalid value `#{node['neo4j']['edition']}` for `node['neo4j']['edition']`, valid are `community enterprise`" unless %w(community enterprise).include?(node['neo4j']['edition'])
+
+include_recipe 'neo4j::java'
+
+# dir resources here
+include_recipe "neo4j::#{node['neo4j']['install_method']}"
+
+[node['neo4j']['log_dir'],
+ node['neo4j']['auth_dir'],
+ node['neo4j']['data_dir']
+].each do |dir|
+  directory dir do
+    owner node['neo4j']['user']
+    group node['neo4j']['group']
+    mode node['neo4j']['mode']
+    recursive true
+  end
 end

--- a/recipes/java.rb
+++ b/recipes/java.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: neo4j
-# Recipe:: default
+# Recipe:: java
 #
-# Copyright (c) 2015 Chris Zeeb <chris.zeeb@gmail.com>
+# Copyright 2015, Virender Khatri
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,5 +17,13 @@
 # limitations under the License.
 #
 
-include_recipe 'neo4j::install'
-include_recipe 'neo4j::config'
+if node['neo4j']['install_java']
+  # Java attributes to meet minimum requirement.
+  node.default['java']['jdk_version'] = '7'
+  node.default['java']['install_flavor'] = 'oracle'
+  node.default['java']['set_default'] = true
+  node.default['java']['arch'] = node['kernel']['machine']
+  node.default['java']['oracle']['accept_oracle_download_terms'] = true
+
+  include_recipe 'java::default'
+end

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook Name:: neo4j
+# Recipe:: install
+#
+# Copyright (c) 2015 Chris Zeeb <chris.zeeb@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform_family']
+when 'debian'
+  # apt repository configuration
+  apt_repository 'neo4j' do
+    uri node['neo4j']['apt']['uri']
+    components node['neo4j']['apt']['components']
+    key node['neo4j']['apt']['key']
+    action node['neo4j']['apt']['action']
+  end
+when 'rhel'
+  # yum repository configuration
+  yum_repository 'neo4j' do
+    description node['neo4j']['yum']['description']
+    baseurl node['neo4j']['yum']['baseurl']
+    mirrorlist node['neo4j']['yum']['mirrorlist']
+    gpgcheck node['neo4j']['yum']['gpgcheck']
+    gpgkey node['neo4j']['yum']['gpgkey']
+    enabled node['neo4j']['yum']['enabled']
+    action node['neo4j']['yum']['action']
+  end
+end
+
+package node['neo4j']['package'] do
+  version node['neo4j']['release'] + node['neo4j']['release_suffix']
+end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -17,14 +17,16 @@
 # limitations under the License.
 #
 
-if node['platform'] == 'debian' && node['platform_version'].to_f >= 8
-  service_provider = Chef::Provider::Service::Systemd
-else
-  service_provider = Chef::Provider::Service::Init::Debian
-end
+service_provider = case node['platform_family']
+                   when 'debian'
+                     if node['platform'] == 'debian' && node['platform_version'].to_f >= 8
+                       Chef::Provider::Service::Systemd
+                     end
+                   end
 
-service 'neo4j-service' do
+service 'neo4j' do
+  service_name 'neo4j-service' if node['platform_family'] == 'debian'
   action [:enable, :start]
   supports :restart => true
-  provider service_provider
+  provider service_provider if node['neo4j']['install_method'] == 'package'
 end

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -29,7 +29,7 @@ include_recipe 'neo4j::user'
   end
 end
 
-tarball_file  = ::File.join(node['neo4j']['parent_dir'], "neo4j-#{node['neo4j']['edition']}-#{node['neo4j']['release']}-unix.tar.gz")
+tarball_file = ::File.join(node['neo4j']['parent_dir'], "neo4j-#{node['neo4j']['edition']}-#{node['neo4j']['release']}-unix.tar.gz")
 
 # stop neo4j service if running for upgrade
 service 'neo4j' do

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -1,0 +1,77 @@
+#
+# Cookbook Name:: neo4j
+# Recipe:: tarball
+#
+# Copyright 2015, Virender Khatri
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'neo4j::user'
+
+[node['neo4j']['parent_dir']
+].each do |dir|
+  directory dir do
+    owner node['neo4j']['user']
+    group node['neo4j']['group']
+    mode node['neo4j']['mode']
+    recursive true
+  end
+end
+
+tarball_file  = ::File.join(node['neo4j']['parent_dir'], "neo4j-#{node['neo4j']['edition']}-#{node['neo4j']['release']}-unix.tar.gz")
+
+# stop neo4j service if running for upgrade
+service 'neo4j' do
+  service_name 'neo4j-service' if node['platform_family'] == 'debian'
+  action :stop
+  only_if { ::File.exist?(node['neo4j']['initd_file']) && !File.exist?(node['neo4j']['source_dir']) }
+end
+
+# download tarball
+remote_file tarball_file do
+  source node['neo4j']['tarball_url']
+  checksum node['neo4j']['tarball_checksum'][node['neo4j']['release']][node['neo4j']['edition']]
+  owner node['neo4j']['user']
+  group node['neo4j']['group']
+  not_if { ::File.exist?(::File.join(node['neo4j']['source_dir'], 'bin', 'neo4j')) }
+end
+
+# extract tarball
+execute 'extract_neo4j_tarball' do
+  user node['neo4j']['user']
+  group node['neo4j']['group']
+  umask node['neo4j']['umask']
+  cwd node['neo4j']['parent_dir']
+  command "tar xzf #{tarball_file}"
+  creates ::File.join(node['neo4j']['source_dir'], 'bin', 'neo4j')
+end
+
+remote_file tarball_file do
+  action :delete
+end
+
+link node['neo4j']['install_dir'] do
+  to node['neo4j']['source_dir']
+  notifies :restart, 'service[neo4j]', :delayed if node['neo4j']['notify_restart']
+end
+
+# initd file
+template node['neo4j']['initd_file'] do
+  cookbook node['neo4j']['cookbook']
+  source "initd.#{node['platform_family']}.erb"
+  owner 'root'
+  group 'root'
+  mode 0755
+  notifies :restart, 'service[neo4j]', :delayed if node['neo4j']['notify_restart']
+end

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: neo4j
+# Recipe:: user
+#
+# Copyright 2015, Virender Khatri
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Note: used when node['neo4j']['install_method']  == 'tarball',
+# node['neo4j']['install_method']  == 'package' auto install
+# neo4j service user/group
+#
+# WARNING:
+# User setup by this recipe may not provide a unique
+# user/group id across nodes and could create problem
+# of non-unique next available user id for User
+# management cookbook.
+#
+# It is advised to use a User management recipe instead
+# for Production systems.
+#
+
+group node['neo4j']['user_group'] do
+  system true if node['platform_family'] == 'rhel'
+  action :create
+  only_if { node['neo4j']['setup_user'] }
+end
+
+user node['neo4j']['user'] do
+  system true if node['platform_family'] == 'rhel'
+  # shell '/bin/false'
+  gid node['neo4j']['user_group']
+  action :create
+  only_if { node['neo4j']['setup_user'] }
+end

--- a/spec/recipes/config_spec.rb
+++ b/spec/recipes/config_spec.rb
@@ -2,22 +2,32 @@ require_relative '../spec_helper.rb'
 
 describe 'neo4j::config' do
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
-  let(:neo4j_server_properties_template) { chef_run.template('/etc/neo4j/neo4j-server.properties') }
-  let(:neo4j_properties_template) { chef_run.template('/etc/neo4j/neo4j.properties') }
-  let(:neo4j_wrapper_template) { chef_run.template('/etc/neo4j/neo4j-wrapper.conf') }
+  let(:neo4j_server_properties_template) { chef_run.template('/var/lib/neo4j/conf/neo4j-server.properties') }
+  let(:neo4j_properties_template) { chef_run.template('/var/lib/neo4j/conf/neo4j.properties') }
+  let(:neo4j_wrapper_template) { chef_run.template('/var/lib/neo4j/conf/neo4j-wrapper.conf') }
+  let(:neo4j_logging_properties_template) { chef_run.template('/var/lib/neo4j/conf/logging.properties') }
 
-  it 'should create /etc/neo4j/neo4j-server.properties' do
-    expect(chef_run).to create_template('/etc/neo4j/neo4j-server.properties')
-    expect(neo4j_server_properties_template).to notify('service[neo4j-service]').delayed
+  it 'should create /var/lib/neo4j/conf/neo4j-server.properties' do
+    expect(chef_run).to create_template('/var/lib/neo4j/conf/neo4j-server.properties')
+    expect(neo4j_server_properties_template).to notify('service[neo4j]').delayed
   end
 
-  it 'should create /etc/neo4j/neo4j.properties' do
-    expect(chef_run).to create_template('/etc/neo4j/neo4j.properties')
-    expect(neo4j_server_properties_template).to notify('service[neo4j-service]').delayed
+  it 'should create /var/lib/neo4j/conf/neo4j.properties' do
+    expect(chef_run).to create_template('/var/lib/neo4j/conf/neo4j.properties')
+    expect(neo4j_server_properties_template).to notify('service[neo4j]').delayed
   end
 
-  it 'should create /etc/neo4j/neo4j-wrapper.conf' do
-    expect(chef_run).to create_template('/etc/neo4j/neo4j-wrapper.conf')
-    expect(neo4j_server_properties_template).to notify('service[neo4j-service]').delayed
+  it 'should create /var/lib/neo4j/conf/neo4j-wrapper.conf' do
+    expect(chef_run).to create_template('/var/lib/neo4j/conf/neo4j-wrapper.conf')
+    expect(neo4j_server_properties_template).to notify('service[neo4j]').delayed
+  end
+
+  it 'should create /var/lib/neo4j/conf/logging.properties' do
+    expect(chef_run).to create_template('/var/lib/neo4j/conf/logging.properties')
+    expect(neo4j_logging_properties_template).to notify('service[neo4j]').delayed
+  end
+
+  it 'includes the neo4j::service recipe' do
+    expect(chef_run).to include_recipe('neo4j::service')
   end
 end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -3,15 +3,11 @@ require_relative '../spec_helper.rb'
 describe 'neo4j::default' do
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-  it 'includes the apt recipe' do
-    expect(chef_run).to include_recipe('apt')
-  end
-
-  it 'includes the java recipe' do
-    expect(chef_run).to include_recipe('java')
-  end
-
   it 'includes the neo4j::install recipe' do
     expect(chef_run).to include_recipe('neo4j::install')
+  end
+
+  it 'includes the neo4j::config recipe' do
+    expect(chef_run).to include_recipe('neo4j::config')
   end
 end

--- a/spec/recipes/install_spec.rb
+++ b/spec/recipes/install_spec.rb
@@ -3,11 +3,51 @@ require_relative '../spec_helper.rb'
 describe 'neo4j::install' do
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-  it 'should install neo4j apt repository' do
-    expect(chef_run).to add_apt_repository('neo4j')
+  it 'includes the neo4j::java recipe' do
+    expect(chef_run).to include_recipe('neo4j::java')
   end
 
-  it 'should install neo4j' do
-    expect(chef_run).to install_package('neo4j').with(version: '2.2.3')
+  it 'creates neo4j log directory' do
+    expect(chef_run).to create_directory('/var/log/neo4j')
+  end
+
+  context 'rhel' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5').converge(described_recipe)
+    end
+
+    it 'creates neo4j auth file directory' do
+      expect(chef_run).to create_directory('/usr/share/neo4j/data/dbms')
+    end
+
+    it 'creates neo4j data directory' do
+      expect(chef_run).to create_directory('/var/lib/neo4j')
+    end
+  end
+
+  context 'ubuntu' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04').converge(described_recipe)
+    end
+
+    it 'creates neo4j auth file directory' do
+      expect(chef_run).to create_directory('/var/lib/neo4j/data/dbms')
+    end
+
+    it 'creates neo4j data directory' do
+      expect(chef_run).to create_directory('/var/lib/neo4j/data/graph.db')
+    end
+  end
+
+  it 'includes the neo4j::package recipe when  install_method = tarball' do
+    chef_run.node.set['neo4j']['install_method'] = 'tarball'
+    chef_run.converge(described_recipe)
+    expect(chef_run).to include_recipe('neo4j::tarball')
+  end
+
+  it 'includes the neo4j::package recipe when  install_method = package' do
+    chef_run.node.set['neo4j']['install_method'] = 'package'
+    chef_run.converge(described_recipe)
+    expect(chef_run).to include_recipe('neo4j::package')
   end
 end

--- a/spec/recipes/package_spec.rb
+++ b/spec/recipes/package_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../spec_helper.rb'
+
+describe 'neo4j::install' do
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+  context 'rhel' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5').converge(described_recipe)
+    end
+
+    it 'should install neo4j yum repository' do
+      expect(chef_run).to create_yum_repository('neo4j')
+    end
+
+    it 'should install neo4j' do
+      expect(chef_run).to install_package('neo4j').with(version: '2.2.4-1')
+    end
+  end
+
+  context 'ubuntu' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04').converge(described_recipe)
+    end
+
+    it 'should install neo4j apt repository' do
+      expect(chef_run).to add_apt_repository('neo4j')
+    end
+
+    it 'should install neo4j' do
+      expect(chef_run).to install_package('neo4j').with(version: '2.2.4')
+    end
+  end
+end

--- a/spec/recipes/service_spec.rb
+++ b/spec/recipes/service_spec.rb
@@ -3,8 +3,8 @@ require_relative '../spec_helper.rb'
 describe 'neo4j::service' do
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-  it 'manage neo4j-service service' do
-    expect(chef_run).to start_service('neo4j-service')
-    expect(chef_run).to enable_service('neo4j-service')
+  it 'manage neo4j service' do
+    expect(chef_run).to start_service('neo4j')
+    expect(chef_run).to enable_service('neo4j')
   end
 end

--- a/spec/recipes/tarball_spec.rb
+++ b/spec/recipes/tarball_spec.rb
@@ -1,0 +1,49 @@
+require_relative '../spec_helper.rb'
+
+describe 'neo4j::tarball' do
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+  it 'includes the neo4j::user recipe' do
+    expect(chef_run).to include_recipe('neo4j::user')
+  end
+
+  it 'creates neo4j parent directory for tarball install method' do
+    expect(chef_run).to create_directory('/usr/local/neo4j')
+  end
+
+  it 'downloads neo4j tarball archive' do
+    expect(chef_run).to create_remote_file('/usr/local/neo4j/neo4j-community-2.2.4-unix.tar.gz')
+  end
+
+  it 'extracts neo4j tarball' do
+    expect(chef_run).to run_execute('extract_neo4j_tarball')
+  end
+
+  it 'deletes neo4j tarball archive' do
+    expect(chef_run).to delete_remote_file('/usr/local/neo4j/neo4j-community-2.2.4-unix.tar.gz')
+  end
+
+  it 'links current neo4j release directory to /usr/local/neo4j/neo4j' do
+    expect(chef_run).to create_link('/usr/local/neo4j/neo4j')
+  end
+
+  context 'rhel' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5').converge(described_recipe)
+    end
+
+    it 'creates neo4j service template' do
+      expect(chef_run).to create_template('/etc/init.d/neo4j')
+    end
+  end
+
+  context 'ubuntu' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04').converge(described_recipe)
+    end
+
+    it 'creates neo4j service template' do
+      expect(chef_run).to create_template('/etc/init.d/neo4j-service')
+    end
+  end
+end

--- a/spec/recipes/user_spec.rb
+++ b/spec/recipes/user_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../spec_helper.rb'
+
+describe 'neo4j::user' do
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+  it 'adds user neo4j' do
+    expect(chef_run).to create_user('neo4j')
+  end
+
+  context 'rhel' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5').converge(described_recipe)
+    end
+
+    it 'adds group neo4j' do
+      expect(chef_run).to create_group('neo4j')
+    end
+  end
+
+  context 'ubuntu' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04').converge(described_recipe)
+    end
+
+    it 'adds group nogroup' do
+      expect(chef_run).to create_group('nogroup')
+    end
+  end
+end

--- a/templates/default/initd.debian.erb
+++ b/templates/default/initd.debian.erb
@@ -1,0 +1,158 @@
+#! /bin/sh
+#
+# This configuration file is managed by chef
+# Do not edit by hand.  Your changes will be overwritten
+#
+### BEGIN INIT INFO
+# Provides:          neo4j
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Neo4j Graph Database server
+# Description:       Neo4j is a Graph Database, which is a compelling
+#                    alternative to an RDBMS. http://www.neo4j.org
+### END INIT INFO
+
+# Author: Julian Simpson <julian.simpson@neotechnology.com>
+#
+# Copyright (c) 2002-2015 "Neo Technology,"
+
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Neo4j Graph Database"
+NAME=neo4j
+DAEMON=<%= node['neo4j']['home_dir'] %>/bin/$NAME
+DAEMON_ARGS="start"
+PIDFILE=<%= node['neo4j']['pid_file'] %>
+SCRIPTNAME=/etc/init.d/$NAME-service
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+. /lib/lsb/init-functions
+
+export JAVA_HOME
+
+checkjava() {
+  if [ -x "$JAVA_HOME/bin/java" ]; then
+    JAVA="$JAVA_HOME/bin/java"
+  else
+    JAVA=`which java`
+  fi
+
+  if [ ! -x "$JAVA" ]; then
+    echo "unable to locate java executable binary. Please install java in your PATH or set JAVA_HOME"
+    exit 1
+  fi
+}
+
+checkdaemon() {
+  if [ ! -x "$DAEMON" ]; then
+    echo "$DAEMON does not exists or not executable"
+    exit 5
+  fi
+}
+
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+  checkjava
+  checkdaemon
+  ulimit -n <%= node['neo4j']['limits']['files'] %>
+	start-stop-daemon --chuid ${NEO_USER} --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+		|| return 1
+	start-stop-daemon --chuid ${NEO_USER} --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+		$DAEMON_ARGS \
+		|| return 2
+}
+
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --chuid ${NEO_USER} --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+
+	start-stop-daemon --chuid ${NEO_USER} --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	[ "$?" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+# Ensure that the NEO_USER is set to a useful default.
+[ -n "${NEO_USER}" ] || NEO_USER=$NAME
+
+case "$1" in
+  start)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+       status_of_proc -p $PIDFILE "$DAEMON" "$NAME" && exit 0 || exit $?
+       ;;
+  restart|force-reload)
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+	  # Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+:

--- a/templates/default/initd.rhel.erb
+++ b/templates/default/initd.rhel.erb
@@ -1,0 +1,151 @@
+#!/bin/sh
+#
+# This configuration file is managed by chef
+# Do not edit by hand.  Your changes will be overwritten
+#
+# neo4j Neo4j Graph Database
+#
+# chkconfig: 2345 99 20
+# processname: java
+# config:      /etc/neo4j/neo4j-server.properties
+# config:      /etc/neo4j/neo4j.properties
+# pidfile:     /var/run/neo4j.pid
+# Provides:          neo4j-service
+# Required-Start:
+# Required-Stop:
+# Should-Start:
+# Should-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: The Neo4J graph database server. See http://neo4j.org
+# Description:
+### END INIT INFO
+
+# Copyright (c) 2002-2015 "Neo Technology,"
+
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Source function library.
+if [ -f /etc/rc.d/init.d/functions ]; then
+  . /etc/rc.d/init.d/functions
+fi
+
+pidfile='<%= node['neo4j']['pid_file'] %>'
+exec='<%= node['neo4j']['home_dir'] %>/bin/neo4j'
+prog='neo4j'
+neo4j_user='<%= node['neo4j']['user'] %>'
+
+[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+lockfile=/var/lock/subsys/$prog
+
+export JAVA_HOME
+
+checkjava() {
+  if [ -x "$JAVA_HOME/bin/java" ]; then
+    JAVA="$JAVA_HOME/bin/java"
+  else
+    JAVA=`which java`
+  fi
+
+  if [ ! -x "$JAVA" ]; then
+    echo "unable to locate java executable binary. Please install java in your PATH or set JAVA_HOME"
+    exit 1
+  fi
+}
+
+checkexec() {
+  if [ ! -x "$exec" ]; then
+    echo "$exec does not exists or not executable"
+    exit 5
+  fi
+}
+
+start() {
+    checkjava
+    checkexec
+    ulimit -n <%= node['neo4j']['limits']['files'] %>
+    echo -n $"Starting $prog: "
+    daemon --user $neo4j_user --pidfile $pidfile $exec start
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc -p $pidfile -d 20 $prog
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    # run checks to determine if the service is running or use generic status
+    status -p $pidfile $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|try-restart|force-reload|condrestart}"
+        exit 2
+esac

--- a/templates/default/logging.properties.erb
+++ b/templates/default/logging.properties.erb
@@ -5,7 +5,7 @@
 ################################################################
 # Neo4j
 #
-# neo4j.properties - database tuning parameters
+# logging.properties - neo4j logging properties file
 #
 ################################################################
 

--- a/templates/default/neo4j-server.properties.erb
+++ b/templates/default/neo4j-server.properties.erb
@@ -1,3 +1,4 @@
+#
 # This configuration file is managed by chef
 # Do not edit by hand.  Your changes will be overwritten
 #
@@ -12,77 +13,9 @@
 # Server configuration
 #***************************************************************
 
-# location of the database directory
-org.neo4j.server.database.location=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.database.location'] %>
+<% Hash[@config.sort].each do |key, value| -%>
+<% if key && !value.nil? -%>
+<%= key %>=<%= value %>
+<% end -%>
+<% end -%>
 
-# Low-level graph engine tuning file
-org.neo4j.server.db.tuning.properties=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.db.tuning.properties'] %>
-
-# Let the webserver only listen on the specified IP. Default is localhost (only
-# accept local connections). Uncomment to allow any connection. Please see the
-# security section in the neo4j manual before modifying this.
-org.neo4j.server.webserver.address=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.address'] %>
-
-# Require (or disable the requirement of) auth to access Neo4j
-dbms.security.auth_enabled=<%= node['neo4j']['neo4j-server.properties']['dbms.security.auth_enabled'] %>
-
-#
-# HTTP Connector
-#
-
-# http port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.port=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.port'] %>
-
-#
-# HTTPS Connector
-#
-
-# Turn https-support on/off
-org.neo4j.server.webserver.https.enabled=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.enabled'] %>
-
-# https port (for all data, administrative, and UI access)
-org.neo4j.server.webserver.https.port=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.https.port'] %>
-
-# Certificate location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.cert.location=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.cert.location'] %>
-
-# Private key location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.key.location=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.key.location'] %>
-
-# Internally generated keystore (don't try to put your own
-# keystore there, it will get deleted when the server starts)
-org.neo4j.server.webserver.https.keystore.location=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.webserver.https.keystore.location'] %>
-
-# Comma separated list of JAX-RS packages containing JAX-RS resources, one
-# package name for each mountpoint. The listed package names will be loaded
-# under the mountpoints specified. Uncomment this line to mount the
-# org.neo4j.examples.server.unmanaged.HelloWorldResource.java from
-# neo4j-server-examples under /examples/unmanaged, resulting in a final URL of
-# http://localhost:7474/examples/unmanaged/helloworld/{nodeId}
-#org.neo4j.server.thirdparty_jaxrs_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged
-
-
-#*****************************************************************
-# HTTP logging configuration
-#*****************************************************************
-
-# HTTP logging is disabled. HTTP logging can be enabled by setting this
-# property to 'true'.
-org.neo4j.server.http.log.enabled=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.http.log.enabled'] %>
-
-# Logging policy file that governs how HTTP log output is presented and
-# archived. Note: changing the rollover and retention policy is sensible, but
-# changing the output format is less so, since it is configured to use the
-# ubiquitous common log format
-org.neo4j.server.http.log.config=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.http.log.config'] %>
-
-
-#*****************************************************************
-# Administration client configuration
-#*****************************************************************
-
-# location of the servers round-robin database directory. Possible values:
-# - absolute path like /var/rrd
-# - path relative to the server working directory like data/rrd
-# - commented out, will default to the database data directory.
-org.neo4j.server.webadmin.rrdb.location=<%= node['neo4j']['neo4j-server.properties']['org.neo4j.server.webadmin.rrdb.location'] %>

--- a/templates/default/neo4j-wrapper.conf.erb
+++ b/templates/default/neo4j-wrapper.conf.erb
@@ -1,40 +1,19 @@
-# This file is managed by chef
+#
+# This configuration file is managed by chef
+# Do not edit by hand.  Your changes will be overwritten
+#
 #
 # Java wrapper.java.additional settings
-<% @node['neo4j']['neo4j-wrapper.conf']['wrapper.java.additional'].each do |java_additional| %>
-wrapper.java.additional=<%= java_additional %>
+
+<% Hash[@config.sort].each do |key, value| -%>
+<% if key -%>
+<% if key == 'wrapper.java.additional' -%>
+<% value.each do |o| -%>
+wrapper.java.additional=<%= o %>
 <% end -%>
-
-# Java Heap Size: by default the Java heap size is dynamically
-# calculated based on available system resources.
-# Uncomment these lines to set specific initial and maximum
-# heap size in MB.
-#wrapper.java.initmemory=512
-#wrapper.java.maxmemory=512
-<% if node['neo4j']['neo4j-wrapper.conf']['wrapper.java.initmemory'] %>
-wrapper.java.initmemory=<%= node['neo4j']['neo4j-wrapper.conf']['wrapper.java.initmemory'] %>
+<% elsif !value.nil? -%>
+<%= key %>=<%= value %>
 <% end -%>
-<% if node['neo4j']['neo4j-wrapper.conf']['wrapper.java.maxmemory'] %>
-wrapper.java.maxmemory=<%= node['neo4j']['neo4j-wrapper.conf']['wrapper.java.maxmemory'] %>
 <% end -%>
-
-#********************************************************************
-# Wrapper settings
-#********************************************************************
-# path is relative to the bin dir
-wrapper.pidfile=<%= node['neo4j']['neo4j-wrapper.conf']['wrapper.pidfile'] %>
-
-#********************************************************************
-# Wrapper Windows NT/2000/XP Service Properties
-#********************************************************************
-# WARNING - Do not modify any of these properties when an application
-#  using this configuration file has been installed as a service.
-#  Please uninstall the service before modifying this section.  The
-#  service can then be reinstalled.
-
-# Name of the service
-wrapper.name=neo4j
-
-# User account to be used for linux installs. Will default to current
-# user if not set.
-wrapper.user=
+<% end -%>
+wrapper.java.additional=-Dneo4j.ext.udc.source=<%= node['platform_family'] == 'rhel' ? 'rpm' : 'debian' %>

--- a/test/integration/default/serverspec/neo4j_spec.rb
+++ b/test/integration/default/serverspec/neo4j_spec.rb
@@ -7,12 +7,19 @@ describe 'neo4j' do
     it { should be_installed }
   end
 
-  if os[:family] == 'debian' && os[:release] == '8.1'
-    describe service('neo4j-service') do
-      it { should be_running }
+  if os[:family] == 'debian'
+    if os[:release] == '8.1'
+      describe service('neo4j-service') do
+        it { should be_running }
+      end
+    else
+      describe service('neo4j-service') do
+        it { should be_enabled }
+        it { should be_running }
+      end
     end
-  else
-    describe service('neo4j-service') do
+  elsif os[:family] == 'rhel'
+    describe service('neo4j') do
       it { should be_enabled }
       it { should be_running }
     end


### PR DESCRIPTION
hello! this PR is for below list of changes

- add package install support for `rhel` platform family
- add yum repository resource for `rhel` platform family
- add attributes for `yum/apt` resources
- make `java` setup optional
- add support for `tarball` based installation
- move `configuration` files attributes to `default['neo4j']['config']['...']`
- render `configuration` files attributes instead of managing individual parameters
- add resources for core directory locations
- add `chefignore`
- update `.gitignore` for common patterns
- add support for `enterprise` edition tarball installation
- add support for `enterprise` edition package installation
- make resource attribute `backup` configurable with default value `5`
- define global `user/group` node attributes instead of hardcoding for various resources
- use `node['ipaddress'] instead for config parameter `default['neo4j']['config']['neo4j-server.properties']['org.neo4j.server.webserver.address']`
- fix `ulimit` warning for init.d scripts
- restrict `java` heap size to 32G limit
- add `rake` tasks