### PR TITLE
add distribution as an attribute for apt packages

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -8,6 +8,7 @@ default['neo4j']['yum']['mirrorlist'] = nil
 default['neo4j']['yum']['action'] = :create
 
 default['neo4j']['apt']['description'] = 'Neo4j Repository'
+default['neo4j']['apt']['distribution'] = nil
 default['neo4j']['apt']['components'] = ['stable/']
 default['neo4j']['apt']['action'] = :add
 default['neo4j']['apt']['uri'] = 'http://debian.neo4j.org/repo'

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -23,6 +23,7 @@ when 'debian'
   # apt repository configuration
   apt_repository 'neo4j' do
     uri node['neo4j']['apt']['uri']
+    distribution node['neo4j']['apt']['distribution']
     components node['neo4j']['apt']['components']
     key node['neo4j']['apt']['key']
     action node['neo4j']['apt']['action']


### PR DESCRIPTION
The newest chef client has a built in apt_repository resource that sets distribution to node['lsb']['codname'] of not set to anything. This breaks your cookbook because the neo4j repo does not work if distribution is set. This should fix the issue without breaking anything backwards.

Thanks!
